### PR TITLE
Re-arranged Tutorials according to Stack.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -144,32 +144,35 @@ const config: Config = {
           label: 'Fuse Network',
         },
         {
-          type: 'dropdown',
+          type: 'docSidebar',
           position: 'left',
           label: 'FuseBox',
-          items: [
-            {
-              label: 'Getting Started',
-              to: 'fuse-box/getting-started',
-            },
-            {
-              label: 'SDK Reference',
-              to: 'fuse-box/sdk',
-            },
-            {
-              label: 'Tutorials & Guides',
-              to: 'category/tutorials',
-            },
-            {
-              type: 'docSidebar',
-              label: 'API Reference',
-              sidebarId: 'apiSidebar',
-            },
-            {
-              label: 'Trade API (versioned)',
-              to: '/category/trade-versioned-api',
-            },
-          ],
+          sidebarId: 'fuseBoxSidebar'
+          // The Items section below is used to create a dropdown menu. 
+          // The dropdown menu requires removing the 'sidebarId'
+          // items: [
+          //   {
+          //     label: 'Getting Started',
+          //     to: 'fuse-box/getting-started',
+          //   },
+          //   {
+          //     label: 'SDK Reference',
+          //     to: 'fuse-box/sdk',
+          //   },
+          //   {
+          //     label: 'Tutorials & Guides',
+          //     to: 'category/tutorials',
+          //   },
+          //   {
+          //     type: 'docSidebar',
+          //     label: 'API Reference',
+          //     sidebarId: 'apiSidebar',
+          //   },
+          //   {
+          //     label: 'Trade API (versioned)',
+          //     to: '/category/trade-versioned-api',
+          //   },
+          // ],
         },
         {
           type: 'docSidebar',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -145,6 +145,12 @@ const config: Config = {
         },
         {
           type: 'docSidebar',
+          sidebarId: 'validatorsSidebar',
+          position: 'left',
+          label: 'Validators',
+        },
+        {
+          type: 'docSidebar',
           position: 'left',
           label: 'FuseBox',
           sidebarId: 'fuseBoxSidebar'
@@ -175,11 +181,11 @@ const config: Config = {
           // ],
         },
         {
-          type: 'docSidebar',
-          sidebarId: 'validatorsSidebar',
-          position: 'left',
-          label: 'Validators',
-        },
+            type: "docSidebar",
+            sidebarId: "apiSidebar",
+            label: "API References",
+            position: "left",
+          },
       ],
     },
     footer: {


### PR DESCRIPTION
Mark gave feedback on removing the dropdown navigation from FuseBox.
This is to improve the UX by removing double developer click actions. 

@LiorAgnin 