### PR TITLE
docs: add OpenChainBench live RPC benchmark reference

### DIFF
--- a/docs/developers/building-on-fuse/rpc.mdx
+++ b/docs/developers/building-on-fuse/rpc.mdx
@@ -24,6 +24,8 @@ sidebar_position: 2
 
 Fuse Archive node RPC: [https://explorer-node.fuse.io/](https://explorer-node.fuse.io/)
 
+For live latency comparisons across Fuse RPC providers, see [OpenChainBench — Fuse RPC Benchmark](https://openchainbench.com/benchmarks/fuse-rpc).
+
 ## Pocket Network
 
 [Pocket Network](https://www.pokt.network/) is a decentralized RPC infrastructure provider with 52,000+ nodes across 25+ countries, offering true decentralization for blockchain access. Pocket provides a cost-effective alternative to centralized providers like Infura, Alchemy, and QuickNode, with 70–80% cost reduction through a per-million-requests pricing model via staked token burn.


### PR DESCRIPTION
## Summary

[OpenChainBench](https://openchainbench.com) is an independent, open benchmark that continuously measures the latency of free, no-key public RPC endpoints.

This PR adds a single reference line after the existing Fuse RPC provider table pointing to the live Fuse benchmark page: https://openchainbench.com/benchmarks/fuse-rpc

The benchmark:
- Measures 3 providers (Fuse Foundation, dRPC, Thirdweb) every 60 seconds
- Probes from 3 global regions
- Requires no API key — all endpoints tested are public and free
- Useful for developers choosing between providers or debugging latency issues

The line was placed just after the archive node note so it sits naturally at the end of the provider reference section without disrupting the existing table or footnotes.